### PR TITLE
Add Google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ ext {
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'


### PR DESCRIPTION
Hello,

This patch fixes this error:
```
A problem occurred configuring root project 'linkasanote'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.android.tools.build:gradle:3.0.1.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.jar
     Required by:
         project :
```